### PR TITLE
chore: consume the bindings toolbox and declare the upstream manifest

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   cd:
     if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-simple-cd.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-simple-cd.yml@v1
     with:
       generator-project: "RenderDocGen/RenderDocGen/RenderDocGen.csproj"  # Path to your generator .csproj
       generator-name: "RenderDoc"                # Name of your generator executable

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-common-ci.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-common-ci.yml@v1
     with:
       generator-project: "RenderDocGen/RenderDocGen/RenderDocGen.csproj"  # Path to your generator .csproj
       generator-name: "RenderDoc"                # Name of your generator executable

--- a/binding.yml
+++ b/binding.yml
@@ -1,0 +1,30 @@
+# Binding manifest — see https://github.com/EvergineTeam/Evergine.Bindings
+# Schema: https://github.com/EvergineTeam/Evergine.Bindings/blob/main/binding.schema.json
+toolbox: 1.0.0
+
+package:
+  id: Evergine.Bindings.RenderDoc
+  project: RenderDocGen/Evergine.Bindings.RenderDoc/Evergine.Bindings.RenderDoc.csproj
+  target-framework: net10.0
+  runtime-identifier: win-x64
+
+upstream:
+  kind: git-tree
+  language: cpp
+  project: https://github.com/baldurk/renderdoc
+  version-from: git-release
+  sources:
+    # `v1.x` is RenderDoc's long-lived release branch, not a tag. The API header is an
+    # in-application interface that only grows additively, so tracking the branch is
+    # safe here in a way it would not be for a struct-layout header.
+    - repo: baldurk/renderdoc
+      ref: v1.x
+      remote-path: renderdoc/api/app/renderdoc_app.h
+      path: RenderDocGen/RenderDocGen/Headers/renderdoc_app.h
+      format: c-header
+
+generator:
+  project: RenderDocGen/RenderDocGen/RenderDocGen.csproj
+  name: RenderDoc
+  output:
+    - RenderDocGen/Evergine.Bindings.RenderDoc/Generated


### PR DESCRIPTION
**El último repo de la flota que seguía apuntando a `evergine-standards`.** Con este se cierra la Fase 2.

## Qué cambia

Dos líneas —el `uses:` de `CI.yml` y el de `CD.yml`, de `evergine-standards@v2` al toolbox `@v1`— más el manifiesto.

Viene de `@v2`, que es byte-idéntico a las copias del toolbox, así que **debe ser un no-op demostrable**: se compara el `.nupkg` producido contra el del run anterior antes de mergear.

## Sobre el manifiesto

Registra que `renderdoc_app.h` viene de la rama `v1.x` de `baldurk/renderdoc`. **Seguir una rama en vez de un tag es deliberado aquí**, y el manifiesto lo explica: la API de RenderDoc es una interfaz in-application que solo crece de forma aditiva, así que no tiene el riesgo de layout de structs que obliga a pinear en otros repos de la flota.

## Por qué estaba parado

Se dejó fuera de la Fase 2 porque tiene **dos runs de `Sync standards` atascados en `queued` desde el 1 de agosto** — siguen así 27 horas después, pasado el punto en que el propio límite de GitHub debería haberlos cancelado.

Migrar igualmente es seguro: `sync-standards.yml` no se toca, y OpenGL.NET estaba en el mismo estado y migró sin incidencias. Los runs atascados quedan como tarea aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)