### PR TITLE
feat: track renderdoc_app.h and regenerate when it moves

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,6 +1,8 @@
-# Binding Simple CD - Template
+# Binding Tracked CD - Template
 
-# This template is for pure .NET bindings (no XML update) to publish NuGets to Nuget.org.
+# This template is for bindings that follow an upstream specification declared in
+# binding.yml: the workflow fetches it, regenerates, and publishes only when the
+# generated API changed.
 # Copy this file to your repository as `.github/workflows/CD.yml` and customize the inputs below.
 
 name: CD
@@ -13,11 +15,18 @@ on:
         required: false
         type: boolean
         default: false
+      force-publish:
+        description: 'Publish even if the generated API did not change (for shipping a reviewed regeneration)'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    - cron: '30 1 1 * *' # Monthly update on day 1 at 01:30
 
 jobs:
   cd:
     if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
-    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-simple-cd.yml@v1
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-tracked-cd.yml@v1
     with:
       generator-project: "RenderDocGen/RenderDocGen/RenderDocGen.csproj"  # Path to your generator .csproj
       generator-name: "RenderDoc"                # Name of your generator executable
@@ -28,6 +37,7 @@ jobs:
       runtime-identifier: "win-x64"                # Runtime identifier (win-x64, linux-x64, etc.)
       build-configuration: "Release"               # Build configuration (Release, Debug, etc.)
       revision: ${{ github.run_number }}           # Revision for date-based version (bindings style). Use with bindings.
+      force-publish: ${{ inputs.force-publish || false }}
       publish-enabled: ${{ !inputs.skip-assets-publishing }} # Publish NuGets to Nuget.org
       enable-email-notifications: true             # Enable email notifications on failure
       runner-os: windows-latest                  # OS for the runner (windows-latest, ubuntu-latest, etc.)


### PR DESCRIPTION
Pasa el CD de `binding-simple-cd` —que compila y publica lo que ya esté commiteado— a `binding-tracked-cd`, que lee `binding.yml`, trae el header de `baldurk/renderdoc`, regenera y publica **solo si la API generada cambió**. Con cron mensual, el mismo horario que los tres bindings XML.

```yaml
uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-tracked-cd.yml@v1
schedule: [{ cron: '30 1 1 * *' }]
```

No hay inputs `xml-*`: el origen sale del manifiesto, que ya declara

```yaml
kind: git-tree
repo: baldurk/renderdoc
ref: v1.x
remote-path: renderdoc/api/app/renderdoc_app.h
path: RenderDocGen/RenderDocGen/Headers/renderdoc_app.h
```

## Primera vez para dos cosas

Es el **primer binding generado desde un header C** que funciona así, y el **primer uso real del adaptador `git-tree`** — hasta ahora solo se había ejecutado `http-file`, en los tres repos XML.

Y es el primero que corre la acción de fetch en **Windows**, que hasta `v1.4.1` habría fallado: la acción tenía `python3` hardcodeado, que en esos runners no existe.

## Qué debe pasar en el primer run

El header vendorizado y el upstream son **byte-idénticos** (36.480 b). Así que:

```
Detect generated-code changes  →  "nothing changed"
Generate NuGets                →  skipped
Publish NuGet                  →  skipped
```

**Publicar aquí sería un fallo, no un éxito.** Es la prueba más barata posible del adaptador: un noop que cuesta una llamada HTTP.

Lo que se vigila especialmente es que no diga "cambió" teniendo bytes idénticos — sería el bucle de finales de línea que arregla `v1.4.1`, y significaría regenerar y publicar cada mes sin motivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)